### PR TITLE
Strip whitespace from worker names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### 1.1.2 / 2025-02-03
+* Trim whitespace from worker names when adding / removing from blackhole or dead queue
+
 ### 1.1.1 / 2024-08-27
 * Support for `redis-client` client (used by Sidekiq 7)
 * Remove `Sidekiq::DeadSet#kill` extension.

--- a/lib/sidekiq/killswitch.rb
+++ b/lib/sidekiq/killswitch.rb
@@ -86,7 +86,7 @@ module Sidekiq
       end
 
       def class_to_str(class_or_string)
-        class_or_string.is_a?(String) ? class_or_string : class_or_string.name
+        (class_or_string.is_a?(String) ? class_or_string : class_or_string.name).strip
       end
 
       private

--- a/lib/sidekiq/killswitch/version.rb
+++ b/lib/sidekiq/killswitch/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Killswitch
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/spec/killswitch_spec.rb
+++ b/spec/killswitch_spec.rb
@@ -57,12 +57,31 @@ RSpec.describe Sidekiq::Killswitch do
         expect(redis.hget(Sidekiq::Killswitch::BLACKHOLE_WORKERS_KEY_NAME, 'AnotherWorker')).to eq(time_now.to_s)
       end
     end
+
+    it 'trims whitespaces off worker names' do
+      time_now = stub_time_now
+
+      Sidekiq::Killswitch.blackhole_add_worker("   #{worker_name}   ")
+
+      Sidekiq::Killswitch.redis_pool do |redis|
+        expect(redis.hget(Sidekiq::Killswitch::BLACKHOLE_WORKERS_KEY_NAME, worker_name)).to eq(time_now.to_s)
+      end
+    end
   end
 
   describe '.blackhole_remove_worker' do
     it 'should remove worker from the list of blackholed workers' do
       Sidekiq::Killswitch.blackhole_add_worker(worker_name)
       Sidekiq::Killswitch.blackhole_remove_worker(worker_name)
+
+      Sidekiq::Killswitch.redis_pool do |redis|
+        expect(redis.hexists(Sidekiq::Killswitch::BLACKHOLE_WORKERS_KEY_NAME, worker_name)).to eq(0)
+      end
+    end
+
+    it 'trims whitespaces off worker names' do
+      Sidekiq::Killswitch.blackhole_add_worker(worker_name)
+      Sidekiq::Killswitch.blackhole_remove_worker("   #{worker_name}   ")
 
       Sidekiq::Killswitch.redis_pool do |redis|
         expect(redis.hexists(Sidekiq::Killswitch::BLACKHOLE_WORKERS_KEY_NAME, worker_name)).to eq(0)
@@ -105,12 +124,31 @@ RSpec.describe Sidekiq::Killswitch do
         expect(redis.hget(Sidekiq::Killswitch::DEAD_QUEUE_WORKERS_KEY_NAME, worker_name)).to eq(time_now.to_s)
       end
     end
+
+    it 'trims whitespaces off worker names' do
+      time_now = stub_time_now
+
+      Sidekiq::Killswitch.dead_queue_add_worker("   #{worker_name}   ")
+
+      Sidekiq::Killswitch.redis_pool do |redis|
+        expect(redis.hget(Sidekiq::Killswitch::DEAD_QUEUE_WORKERS_KEY_NAME, worker_name)).to eq(time_now.to_s)
+      end
+    end
   end
 
   describe '.dead_queue_remove_worker' do
     it 'should remove worker from the list of dead queue workers' do
       Sidekiq::Killswitch.dead_queue_add_worker(worker_name)
       Sidekiq::Killswitch.dead_queue_remove_worker(worker_name)
+
+      Sidekiq::Killswitch.redis_pool do |redis|
+        expect(redis.hexists(Sidekiq::Killswitch::DEAD_QUEUE_WORKERS_KEY_NAME, worker_name)).to eq(0)
+      end
+    end
+
+    it 'trims whitespaces off worker names' do
+      Sidekiq::Killswitch.dead_queue_add_worker(worker_name)
+      Sidekiq::Killswitch.dead_queue_remove_worker("   #{worker_name}   ")
 
       Sidekiq::Killswitch.redis_pool do |redis|
         expect(redis.hexists(Sidekiq::Killswitch::DEAD_QUEUE_WORKERS_KEY_NAME, worker_name)).to eq(0)


### PR DESCRIPTION
Killswitch doesn't strip whitespaces from workers that are added/removed from the blackhole or DLQ, so it's easy for people to accidentally include whitespace in the worker name, which the Sidekiq UI automatically strips.

![Screenshot 2025-02-03 at 2 44 00 PM](https://github.com/user-attachments/assets/e07f548e-6351-44b2-8e6f-8ea61d4e8b04)
